### PR TITLE
fix issue with usernames that contain spaces

### DIFF
--- a/EnvyUpdate/DashboardPage.xaml.cs
+++ b/EnvyUpdate/DashboardPage.xaml.cs
@@ -420,7 +420,7 @@ namespace EnvyUpdate
                 WindowStyle = ProcessWindowStyle.Minimized,
                 WorkingDirectory = destinationDir,
                 FileName = sevenZipPath,
-                Arguments = "x -aoa -y " + filePath + " Display.Driver Display.Nview Display.Optimus HDAudio MSVCR NVI2 NVPCF PhysX PPC ShieldWirelessController EULA.txt ListDevices.txt setup.cfg setup.exe"
+                Arguments = "x -aoa -y \"" + filePath + "\" Display.Driver Display.Nview Display.Optimus HDAudio MSVCR NVI2 NVPCF PhysX PPC ShieldWirelessController EULA.txt ListDevices.txt setup.cfg setup.exe"
             };
             process.EnableRaisingEvents = true;
             process.StartInfo = startInfo;


### PR DESCRIPTION
This fixes an issue where the 7zip executable is unable to find the nvidia installer due to a space in a username. 

Closes #38